### PR TITLE
feat: update ESLint & TypeScript plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "extends": "./lib/index.js",
-  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"
   }

--- a/package.json
+++ b/package.json
@@ -52,25 +52,25 @@
     "TypeScript"
   ],
   "dependencies": {
-    "eslint-config-standard": "^12.0.0"
+    "@typescript-eslint/parser": "^1.13.0",
+    "eslint-config-standard": "^13.0.1"
   },
   "peerDependencies": {
-    "eslint": "^5.8.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^9.0.0",
-    "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-standard": "^4.0.0",
-    "@typescript-eslint/eslint-plugin": "^1.4.2",
-    "@typescript-eslint/parser": "^1.4.2"
+    "eslint": ">=6.0.1",
+    "eslint-config-standard": ">=13.0.1",
+    "eslint-plugin-import": ">=2.18.0",
+    "eslint-plugin-node": ">=9.1.0",
+    "eslint-plugin-promise": ">=4.2.1",
+    "eslint-plugin-standard": ">=4.0.0",
+    "@typescript-eslint/eslint-plugin": ">=1.10.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
     "@types/node": "^12.6.9",
-    "@typescript-eslint/eslint-plugin": "^1.9.0",
-    "@typescript-eslint/parser": "^1.11.0",
-    "eslint": "^5.16.0",
+    "@typescript-eslint/eslint-plugin": "^1.10.2",
+    "eslint": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.2.1",

--- a/readme.md
+++ b/readme.md
@@ -10,15 +10,14 @@ An [ESLint shareable config](https://eslint.org/docs/developer-guide/shareable-c
 ## Usage
 
 ```
-npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-standard-with-typescript 
+npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node @typescript-eslint/eslint-plugin
 ```
 
-Yes, I know it is a large number of packages. This is due to [a known design flaw in ESLint](https://github.com/eslint/eslint/issues/10125).
+Yes, I know it is a large number of packages. This is due to [a known limitation in ESLint](https://github.com/eslint/eslint/issues/3458).
 
 This long list of dependencies includes:
 
 1. Peer dependencies of [eslint-config-standard](https://github.com/standard/eslint-config-standard)
-1. the necessary [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser); lets ESLint parse TypeScript.
 1. [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin); ESLint rules for TypeScript.
 
 Here is an example `.eslintrc.json`:
@@ -26,7 +25,6 @@ Here is an example `.eslintrc.json`:
 ```json
 {
   "extends": "standard-with-typescript",
-  "parser": "@typescript-eslint/parser",
   "parserOptions": {
       "project": "./tsconfig.json"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 export = {
+  parser: '@typescript-eslint/parser',
   extends: 'eslint-config-standard',
   plugins: ['@typescript-eslint'],
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
       rules: {
-        'camelcase': 'off', // in favor of TypeScript rule
-        'indent': 'off',
+        camelcase: 'off', // in favor of TypeScript rule
+        indent: 'off',
         'no-array-constructor': 'off',
         'no-undef': 'off', // TypeScript has this functionality by default
         'no-unused-vars': 'off', // in favor of TypeScript rule
@@ -14,21 +15,23 @@ export = {
         '@typescript-eslint/adjacent-overload-signatures': 'error',
         '@typescript-eslint/array-type': ['error', 'array-simple'],
         '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
-        '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/explicit-function-return-type': ['error', {
+          allowHigherOrderFunctions: true
+        }],
         '@typescript-eslint/explicit-member-accessibility': 'error',
         '@typescript-eslint/indent': ['error', 2, {
-          'SwitchCase': 1,
-          'VariableDeclarator': 1,
-          'outerIIFEBody': 1,
-          'MemberExpression': 1,
-          'FunctionDeclaration': { 'parameters': 1, 'body': 1 },
-          'FunctionExpression': { 'parameters': 1, 'body': 1 },
-          'CallExpression': { 'arguments': 1 },
-          'ArrayExpression': 1,
-          'ObjectExpression': 1,
-          'ImportDeclaration': 1,
-          'flatTernaryExpressions': false,
-          'ignoreComments': false
+          SwitchCase: 1,
+          VariableDeclarator: 1,
+          outerIIFEBody: 1,
+          MemberExpression: 1,
+          FunctionDeclaration: { parameters: 1, body: 1 },
+          FunctionExpression: { parameters: 1, body: 1 },
+          CallExpression: { arguments: 1 },
+          ArrayExpression: 1,
+          ObjectExpression: 1,
+          ImportDeclaration: 1,
+          flatTernaryExpressions: false,
+          ignoreComments: false
         }],
         '@typescript-eslint/member-delimiter-style': [
           'error',


### PR DESCRIPTION
BREAKING CHANGE: `eslint-config-standard` has been updated to `13.0.1`.
BREAKING CHANGE: Updatd all peer dependencies. Fixes #80. Fixes #94.

Added option for rule `@typescript-eslint/explicit-function-return-type`: `allowHigherOrderFunctions: true`.

BREAKING CHANGE: `typescript-eslint/parser` is no longer a `peerDependency`, but a `dependency`. Users should remove it from their configuration, as well. Closes #65.

Updated `@typescript-eslint/eslint-plugin` to `1.10.2`.