### PR TITLE
Update README : add missing dependency  and fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ An [ESLint shareable config](https://eslint.org/docs/developer-guide/shareable-c
 ## Usage
 
 ```
-npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node @typescript-eslint/eslint-plugin
+npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node @typescript-eslint/eslint-plugin eslint-config-standard-with-typescript
 ```
 
 Yes, I know it is a large number of packages. This is due to [a known limitation in ESLint](https://github.com/eslint/eslint/issues/3458).
@@ -27,7 +27,7 @@ Here is an example `.eslintrc.json`:
   "extends": "standard-with-typescript",
   "parserOptions": {
       "project": "./tsconfig.json"
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
- Along with other pieces, eslint-config-standard-with-typescript itself should be installed as well to make things work.
- JSON file doesn't allow putting comma at the end of last property unlike JavaScript object.