### PR TITLE
fix: [no-unused-vars] Allow unused parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export = {
         '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
         '@typescript-eslint/no-triple-slash-reference': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
         '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false, variables: false, typedefs: false }],
         '@typescript-eslint/no-useless-constructor': 'error',
         '@typescript-eslint/no-var-requires': 'error',


### PR DESCRIPTION
The Standard.js rules allow unused parameters in functions.

Typescript also has `noUnusedParameters`, so users can enable / disable that as they see fit. Whatever users choose, eslint-config-standard-with-typescript shouldn't conflict with Standard.js itself.