### PR TITLE
fix: [no-use-before-define] Disable eslint version

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,6 +15,7 @@ test('export', (t): void => {
           'no-array-constructor': 'off',
           'no-undef': 'off',
           'no-unused-vars': 'off',
+          'no-use-before-define': 'off',
           'no-useless-constructor': 'off',
           '@typescript-eslint/adjacent-overload-signatures': 'error',
           '@typescript-eslint/array-type': ['error', 'array-simple'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export = {
         indent: 'off',
         'no-array-constructor': 'off',
         'no-unused-vars': 'off',
+        'no-use-before-define': 'off',
         'no-useless-constructor': 'off',
 
         // @typescript-eslint versions of Standard.js rules:


### PR DESCRIPTION
eslint-config-standard-with-typescript replaces several ESLint rules with @typescript-eslint equivalents, but it missed `no-use-before-define`. To help with this in the future, this commit also organizes the rules by section.

This PR will conflict with #112, so whichever one gets merged first, I'll rebase the other one to match.