### PR TITLE
feat: @typescript-eslint/eslint-plugin@^1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,14 +62,14 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "@typescript-eslint/eslint-plugin": ">=1.11.0"
+    "@typescript-eslint/eslint-plugin": ">=1.12.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
     "@types/node": "^12.7.1",
-    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/eslint-plugin": "^1.12.0",
     "ava": "^2.2.0",
     "eslint": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -8,7 +8,7 @@ export type Foo<Bar> = (a: Bar) => Bar
  * https://github.com/standard/eslint-config-standard-with-typescript/issues/2
  */
 export default class Zoo {
-  public constructor (private name: string) {}
+  public constructor (private readonly name: string) {}
 
   public get greeting (): string {
     return `Hello ${this.name}`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,16 +60,18 @@ test('export', (t): void => {
           '@typescript-eslint/no-non-null-assertion': 'error',
           '@typescript-eslint/no-object-literal-type-assertion': 'error',
           '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
-          '@typescript-eslint/no-triple-slash-reference': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
           '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
           '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false, variables: false, typedefs: false }],
           '@typescript-eslint/no-useless-constructor': 'error',
           '@typescript-eslint/no-var-requires': 'error',
           '@typescript-eslint/prefer-function-type': 'error',
+          '@typescript-eslint/prefer-readonly': 'error',
           '@typescript-eslint/promise-function-async': 'error',
           '@typescript-eslint/restrict-plus-operands': 'error',
           '@typescript-eslint/require-array-sort-compare': 'error',
+          '@typescript-eslint/strict-boolean-expressions': 'error',
+          '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
           '@typescript-eslint/type-annotation-spacing': 'error'
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,13 +66,15 @@ export = {
         '@typescript-eslint/no-non-null-assertion': 'error',
         '@typescript-eslint/no-object-literal-type-assertion': 'error',
         '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
-        '@typescript-eslint/no-triple-slash-reference': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/prefer-function-type': 'error',
+        '@typescript-eslint/prefer-readonly': 'error',
         '@typescript-eslint/promise-function-async': 'error',
         '@typescript-eslint/require-array-sort-compare': 'error',
         '@typescript-eslint/restrict-plus-operands': 'error',
+        '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
         '@typescript-eslint/type-annotation-spacing': 'error'
       }
     }


### PR DESCRIPTION
BREAKING CHANGE: added rule `@typescript-eslint/prefer-readonly` https://github.com/typescript-eslint/typescript-eslint/commit/76b89a5
BREAKING CHANGE: added rule `@typescript-eslint/strict-boolean-expressions` https://github.com/typescript-eslint/typescript-eslint/commit/34e7d1e
BREAKING CHANGE: replaced rule `@typescript-eslint/no-triple-slash-reference` with `@typescript-eslint/no-reference-import` https://github.com/typescript-eslint/typescript-eslint/commit/af70a59