### PR TITLE
feat: upgrade typescript-eslint packages v2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^2.1.0",
+    "@typescript-eslint/parser": "^2.2.0",
     "eslint-config-standard": "^14.1.0"
   },
   "peerDependencies": {
@@ -71,7 +71,7 @@
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^12.7.9",
-    "@typescript-eslint/eslint-plugin": "^2.1.0",
+    "@typescript-eslint/eslint-plugin": "^2.2.0",
     "ava": "^2.4.0",
     "editorconfig-checker": "^3.0.3",
     "eslint": "^6.5.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ test('export', (t): void => {
         files: ['*.ts', '*.tsx'],
         parser: '@typescript-eslint/parser',
         rules: {
+          'brace-style': 'off',
           camelcase: 'off',
           indent: 'off',
           'no-array-constructor': 'off',
@@ -20,6 +21,7 @@ test('export', (t): void => {
           quotes: 'off',
           '@typescript-eslint/adjacent-overload-signatures': 'error',
           '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+          '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
           '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
           '@typescript-eslint/consistent-type-assertions': [
             'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export = {
         'no-undef': 'off',
 
         // Rules replaced by @typescript-eslint versions:
+        'brace-style': 'off',
         camelcase: 'off',
         indent: 'off',
         'no-array-constructor': 'off',
@@ -19,6 +20,7 @@ export = {
         quotes: 'off',
 
         // @typescript-eslint versions of Standard.js rules:
+        '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
         '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
         '@typescript-eslint/indent': ['error', 2, {
           SwitchCase: 1,


### PR DESCRIPTION
BREAKING CHANGE: brace-style now supports TypeScript syntax.