### PR TITLE
fix: replace Object.fromEntries with a custom function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ const equivalents = [
   'quotes'
 ] as const
 
+function fromEntries<T> (iterable: Array<[string, T]>): { [key: string]: T } {
+  return [...iterable].reduce<{ [key: string]: T }>((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {})
+}
+
 export = {
   extends: 'eslint-config-standard',
   plugins: ['@typescript-eslint'],
@@ -22,13 +29,11 @@ export = {
         'no-undef': 'off',
 
         // Rules replaced by @typescript-eslint versions:
-        ...Object.fromEntries(equivalents.map((name) => [name, 'off'])),
+        ...fromEntries(equivalents.map((name) => [name, 'off'])),
         'no-use-before-define': 'off',
 
         // @typescript-eslint versions of Standard.js rules:
-        ...Object.fromEntries(
-          equivalents.map((name) => [`@typescript-eslint/${name}`, standardRules[name]])
-        ),
+        ...fromEntries(equivalents.map((name) => [`@typescript-eslint/${name}`, standardRules[name]])),
         '@typescript-eslint/no-use-before-define': ['error', {
           functions: false,
           classes: false,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to the item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added a custom function that accomplishes the same results as `Object.fromEntries`.

**Which issue (if any) does this pull request address?**
`Object.fromEntries` is only supported on the latest version of Nodejs (v12). This change allows this lib to be used on older versions of Nodejs. Typescript does not transpile `Object.fromEntries` because the ts devs consider it to be a runtime feature (https://github.com/microsoft/TypeScript/issues/32803).

**Is there anything you'd like reviewers to focus on?**
maybe this should just be reverted back to strings for simplicity?
