### PR TITLE
feat: upgrade plugin to v2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "@typescript-eslint/eslint-plugin": ">=2.7.0"
+    "@typescript-eslint/eslint-plugin": ">=2.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^13.1.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "^2.8.0",
     "ava": "^2.4.0",
     "editorconfig-checker": "^3.0.3",
     "eslint": "^6.7.2",

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -29,7 +29,7 @@ export interface Boo { b_oo: null }
  * https://github.com/standard/eslint-config-standard-with-typescript/issues/110
  */
 // Inline callbacks don't need return types:
-setTimeout(() => {}, 1)
+setTimeout(() => { console.log() }, 1)
 
 // The return type is clear from the left side of the assignment:
 const double: ((n: number) => number) = n => n * 2

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,7 @@ test('export', (t): void => {
           'no-unused-expressions': 'off',
           'no-useless-constructor': 'off',
           quotes: 'off',
+          'space-before-function-paren': 'off',
           '@typescript-eslint/adjacent-overload-signatures': 'error',
           '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
           '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
@@ -79,6 +80,7 @@ test('export', (t): void => {
             }
           ],
           '@typescript-eslint/no-array-constructor': 'error',
+          '@typescript-eslint/no-dynamic-delete': 'error',
           '@typescript-eslint/no-empty-function': 'error',
           '@typescript-eslint/no-empty-interface': 'error',
           '@typescript-eslint/no-extraneous-class': 'error',
@@ -102,6 +104,8 @@ test('export', (t): void => {
           '@typescript-eslint/restrict-plus-operands': 'error',
           '@typescript-eslint/require-array-sort-compare': 'error',
           '@typescript-eslint/require-await': 'error',
+          '@typescript-eslint/restrict-template-expressions': 'error',
+          '@typescript-eslint/space-before-function-paren': ['error', 'always'],
           '@typescript-eslint/strict-boolean-expressions': 'error',
           '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
           '@typescript-eslint/type-annotation-spacing': 'error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ const equivalents = [
   'no-unused-vars',
   'no-unused-expressions',
   'no-useless-constructor',
-  'quotes'
+  'quotes',
+  'space-before-function-paren'
 ] as const
 
 function fromEntries<T> (iterable: Array<[string, T]>): { [key: string]: T } {
@@ -66,6 +67,7 @@ export = {
             singleline: { delimiter: 'comma', requireLast: false }
           }
         ],
+        '@typescript-eslint/no-dynamic-delete': 'error',
         '@typescript-eslint/no-empty-function': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
         '@typescript-eslint/no-extraneous-class': 'error',
@@ -84,6 +86,7 @@ export = {
         '@typescript-eslint/require-array-sort-compare': 'error',
         '@typescript-eslint/require-await': 'error',
         '@typescript-eslint/restrict-plus-operands': 'error',
+        '@typescript-eslint/restrict-template-expressions': 'error',
         '@typescript-eslint/strict-boolean-expressions': 'error',
         '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
         '@typescript-eslint/type-annotation-spacing': 'error'


### PR DESCRIPTION
BREAKING CHANGE: add rule @typescript-eslint/restrict-template-expressions
https://github.com/typescript-eslint/typescript-eslint/blob/v2.8.0/packages/eslint-plugin/docs/rules/restrict-template-expressions.md

BREAKING CHANGE: add rule @typescript-eslint/space-before-function-paren
https://github.com/typescript-eslint/typescript-eslint/blob/v2.8.0/packages/eslint-plugin/docs/rules/space-before-function-paren.md

BREAKING CHANGE: add rule @typescript-eslint/no-dynamic-delete
https://github.com/typescript-eslint/typescript-eslint/blob/v2.8.0/packages/eslint-plugin/docs/rules/no-dynamic-delete.md

Closes #175.