### PR TITLE
feat: use @typescript-eslint func-call-spacing equivalent

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,6 +35,7 @@ test('export', (t): void => {
           camelcase: 'off',
           'comma-spacing': 'off',
           'default-param-last': 'off',
+          'func-call-spacing': 'off',
           indent: 'off',
           'no-array-constructor': 'off',
           'no-dupe-class-members': 'off',
@@ -66,6 +67,7 @@ test('export', (t): void => {
             allowTypedFunctionExpressions: true,
             allowDirectConstAssertionInArrowFunctions: true
           }],
+          '@typescript-eslint/func-call-spacing': ['error', 'never'],
           '@typescript-eslint/indent': ['error', 2, {
             SwitchCase: 1,
             VariableDeclarator: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { rules as standardRules } from 'eslint-config-standard/eslintrc.json'
 const equivalents = [
   'comma-spacing',
   'brace-style',
+  'func-call-spacing',
   'indent',
   'no-array-constructor',
   'no-dupe-class-members',


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Replaced eslint default func-call-spacing with @typescript-eslint/func-call-spacing

**Which issue (if any) does this pull request address?**
#232 

**Is there anything you'd like reviewers to focus on?**
No