### PR TITLE
feat: upgrade parser & plugin to 2.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^2.19.2",
+    "@typescript-eslint/parser": "^2.22.0",
     "eslint-config-standard": "^14.1.0"
   },
   "peerDependencies": {
@@ -64,14 +64,14 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "@typescript-eslint/eslint-plugin": ">=2.19.2"
+    "@typescript-eslint/eslint-plugin": ">=2.22.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^13.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.19.2",
+    "@typescript-eslint/eslint-plugin": "^2.22.0",
     "ava": "^3.3.0",
     "editorconfig-checker": "^3.0.3",
     "eslint": "^6.7.2",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -91,6 +91,7 @@ test('export', (t): void => {
             }
           ],
           '@typescript-eslint/no-array-constructor': 'error',
+          '@typescript-eslint/no-base-to-string': 'error',
           '@typescript-eslint/no-dupe-class-members': 'error',
           '@typescript-eslint/no-dynamic-delete': 'error',
           '@typescript-eslint/no-empty-function': ['error', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export = {
             singleline: { delimiter: 'comma', requireLast: false }
           }
         ],
+        '@typescript-eslint/no-base-to-string': 'error',
         '@typescript-eslint/no-dynamic-delete': 'error',
         '@typescript-eslint/no-empty-function': ['error', {
           allow: [


### PR DESCRIPTION
BREAKING CHANGE: parser & plugin v2.22.0 required.

BREAKING CHANGE: added rule @typescript-eslint/no-base-to-string.