### PR TITLE
feat: upgrade parser & plugin to v2.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^2.22.0",
+    "@typescript-eslint/parser": "^2.24.0",
     "eslint-config-standard": "^14.1.0"
   },
   "peerDependencies": {
@@ -64,14 +64,14 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "@typescript-eslint/eslint-plugin": ">=2.22.0"
+    "@typescript-eslint/eslint-plugin": ">=2.24.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^13.7.7",
-    "@typescript-eslint/eslint-plugin": "^2.22.0",
+    "@typescript-eslint/eslint-plugin": "^2.24.0",
     "ava": "^3.5.0",
     "editorconfig-checker": "^3.0.4",
     "eslint": "^6.7.2",


### PR DESCRIPTION
BREAKING CHANGE: parser & plugin upgraded to v2.24.0 and new rules.

New rules:

- @typescript-eslint/no-unsafe-call
- @typescript-eslint/no-unsafe-member-access
- @typescript-eslint/no-unsafe-return

Closes #247.
Closes #250.