### PR TITLE
feat: new rule @typescript-eslint/return-await always

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -125,6 +125,7 @@ test('export', (t): void => {
           '@typescript-eslint/require-array-sort-compare': 'error',
           '@typescript-eslint/require-await': 'error',
           '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+          '@typescript-eslint/return-await': ['error', 'always'],
           '@typescript-eslint/space-before-function-paren': ['error', 'always'],
           '@typescript-eslint/strict-boolean-expressions': 'error',
           '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export = {
         '@typescript-eslint/require-await': 'error',
         '@typescript-eslint/restrict-plus-operands': ['error', { checkCompoundAssignments: true }],
         '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+        '@typescript-eslint/return-await': ['error', 'always'],
         '@typescript-eslint/strict-boolean-expressions': 'error',
         '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
         '@typescript-eslint/type-annotation-spacing': 'error'


### PR DESCRIPTION
BREAKING CHANGE: new rule @typescript-eslint/return-await always

Closes #199.