### PR TITLE
feat: new rule @typescript-eslint/no-unsafe-return

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,6 +109,7 @@ test('export', (t): void => {
           '@typescript-eslint/no-throw-literal': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
           '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+          '@typescript-eslint/no-unsafe-return': 'error',
           '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'none', ignoreRestSiblings: true }],
           '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false, enums: false, variables: false, typedefs: false }],
           '@typescript-eslint/no-unused-expressions': ['error', { allowShortCircuit: true, allowTaggedTemplates: true, allowTernary: true }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export = {
         '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
         '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+        '@typescript-eslint/no-unsafe-return': 'error',
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/prefer-function-type': 'error',
         '@typescript-eslint/prefer-includes': 'error',


### PR DESCRIPTION
BREAKING CHANGE: new rule @typescript-eslint/no-unsafe-return.