### PR TITLE
fix: ignore tagged template strings

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -91,7 +91,7 @@ test('export', (t): void => {
             }
           ],
           '@typescript-eslint/no-array-constructor': 'error',
-          '@typescript-eslint/no-base-to-string': 'error',
+          '@typescript-eslint/no-base-to-string': ['error', { ignoreTaggedTemplateExpressions: true }],
           '@typescript-eslint/no-dupe-class-members': 'error',
           '@typescript-eslint/no-dynamic-delete': 'error',
           '@typescript-eslint/no-empty-interface': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export = {
             singleline: { delimiter: 'comma', requireLast: false }
           }
         ],
-        '@typescript-eslint/no-base-to-string': 'error',
+        '@typescript-eslint/no-base-to-string': ['error', { ignoreTaggedTemplateExpressions: true }],
         '@typescript-eslint/no-dynamic-delete': 'error',
         '@typescript-eslint/no-empty-interface': 'error',
         '@typescript-eslint/no-extra-non-null-assertion': 'error',


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
When using the eslint config with a react project, often-times react components
are embedded in **tagged** template strings for ease of readability and simplicity. 
React will later properly convert those tagged template strings, transforming the
components into their proper representation.

Example:
```tsx
const LegendItem = styled.div`
  font-size: ${rem(25.8)};
  font-weight: 500;
  color: rgba(70, 74, 125, 0.8);
  align-items: center;
`

const Legend = styled.div`   // A `styled.div` tagged template string
  position: absolute;
  right: 3rem;
  top: 2rem;

  ${LegendItem} {            // `LegendItem` is a React Component
    margin-left: ${rem(54)};
  }
`
```

This PR sets the `ignoreTaggedTemplateExpressions = true` on the `no-base-to-string` rule. This causes the `no-base-to-string` rule to be ignored in **tagged** template strings.

**Which issue (if any) does this pull request address?**
N/A

**Is there anything you'd like reviewers to focus on?**
This seems like a good rule change, but perhaps **tagged** template strings are a bad style of programming? Or maybe there is/will be a better way to lint **tagged** template strings in the future?

Related to: https://github.com/typescript-eslint/typescript-eslint/issues/1757
Typescript Eslint Parser Rule Documentation: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md
Depends on: https://github.com/standard/eslint-config-standard-with-typescript/issues/273
