### PR TITLE
fix: upgrade parser & plugin to 2.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^2.26.0",
+    "@typescript-eslint/parser": "^2.29.0",
     "eslint-config-standard": "^14.1.1"
   },
   "peerDependencies": {
@@ -68,14 +68,14 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "@typescript-eslint/eslint-plugin": ">=2.26.0"
+    "@typescript-eslint/eslint-plugin": ">=2.29.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^13.13.2",
-    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/eslint-plugin": "^2.29.0",
     "ava": "^3.7.1",
     "editorconfig-checker": "^3.0.4",
     "eslint": "^6.7.2",


### PR DESCRIPTION
BREAKING CHANGE: plugin peerDep bumped to 2.29.0

Closes #272.
Closes #273.
Closes #277.