### PR TITLE
feat: rule @typescript-eslint/keyword-spacing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,6 +37,7 @@ test('export', (t): void => {
           'default-param-last': 'off',
           'func-call-spacing': 'off',
           indent: 'off',
+          'keyword-spacing': 'off',
           'no-array-constructor': 'off',
           'no-dupe-class-members': 'off',
           'no-throw-literal': 'off',
@@ -84,6 +85,7 @@ test('export', (t): void => {
             ignoreComments: false,
             ignoredNodes: ['TemplateLiteral *']
           }],
+          '@typescript-eslint/keyword-spacing': ['error', { before: true, after: true }],
           '@typescript-eslint/member-delimiter-style': [
             'error',
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ const equivalents = [
   'brace-style',
   'func-call-spacing',
   'indent',
+  'keyword-spacing',
   'no-array-constructor',
   'no-dupe-class-members',
   'no-throw-literal',


### PR DESCRIPTION
BREAKING CHANGE: add extending rule @typescript-eslint/keyword-spacing

https://github.com/typescript-eslint/typescript-eslint/blob/v2.29.0/packages/eslint-plugin/docs/rules/keyword-spacing.md