### PR TITLE
feat: rule @typescript-eslint/prefer-ts-expect-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-node": ">=9.1.0",
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "typescript": ">=3.8",
+    "typescript": ">=3.9",
     "@typescript-eslint/eslint-plugin": ">=2.33.0"
   },
   "devDependencies": {
@@ -89,7 +89,7 @@
     "read-pkg-up": "^7.0.1",
     "standard-version": "^7.1.0",
     "tsconfigs": "^4.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "lib/index.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -129,6 +129,7 @@ test('export', (t): void => {
           '@typescript-eslint/prefer-optional-chain': 'error',
           '@typescript-eslint/prefer-readonly': 'error',
           '@typescript-eslint/prefer-reduce-type-parameter': 'error',
+          '@typescript-eslint/prefer-ts-expect-error': 'error',
           '@typescript-eslint/promise-function-async': 'error',
           '@typescript-eslint/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
           '@typescript-eslint/restrict-plus-operands': ['error', { checkCompoundAssignments: true }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ export = {
         '@typescript-eslint/prefer-optional-chain': 'error',
         '@typescript-eslint/prefer-readonly': 'error',
         '@typescript-eslint/prefer-reduce-type-parameter': 'error',
+        '@typescript-eslint/prefer-ts-expect-error': 'error',
         '@typescript-eslint/promise-function-async': 'error',
         '@typescript-eslint/require-array-sort-compare': 'error',
         '@typescript-eslint/restrict-plus-operands': ['error', { checkCompoundAssignments: true }],


### PR DESCRIPTION
BREAKING CHANGE: add rule @typescript-eslint/prefer-ts-expect-error

https://github.com/typescript-eslint/typescript-eslint/blob/v2.29.0/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md