### PR TITLE
feat: upgrade parser & plugin to 2.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^2.29.0",
+    "@typescript-eslint/parser": "^2.33.0",
     "eslint-config-standard": "^14.1.1"
   },
   "peerDependencies": {
@@ -69,14 +69,14 @@
     "eslint-plugin-promise": ">=4.2.1",
     "eslint-plugin-standard": ">=4.0.0",
     "typescript": ">=3.8",
-    "@typescript-eslint/eslint-plugin": ">=2.29.0"
+    "@typescript-eslint/eslint-plugin": ">=2.33.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/travis-cli": "^8.2.0",
     "@types/node": "^13.13.2",
-    "@typescript-eslint/eslint-plugin": "^2.29.0",
+    "@typescript-eslint/eslint-plugin": "^2.33.0",
     "ava": "^3.7.1",
     "editorconfig-checker": "^3.0.4",
     "eslint": "^6.7.2",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,9 +35,11 @@ test('export', (t): void => {
           camelcase: 'off',
           'comma-spacing': 'off',
           'default-param-last': 'off',
+          'dot-notation': 'off',
           'func-call-spacing': 'off',
           indent: 'off',
           'keyword-spacing': 'off',
+          'lines-between-class-members': 'off',
           'no-array-constructor': 'off',
           'no-dupe-class-members': 'off',
           'no-throw-literal': 'off',
@@ -63,6 +65,7 @@ test('export', (t): void => {
           ],
           '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
           '@typescript-eslint/default-param-last': 'error',
+          '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
           '@typescript-eslint/explicit-function-return-type': ['error', {
             allowExpressions: true,
             allowHigherOrderFunctions: true,
@@ -86,6 +89,7 @@ test('export', (t): void => {
             ignoredNodes: ['TemplateLiteral *']
           }],
           '@typescript-eslint/keyword-spacing': ['error', { before: true, after: true }],
+          '@typescript-eslint/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
           '@typescript-eslint/member-delimiter-style': [
             'error',
             {
@@ -104,6 +108,7 @@ test('export', (t): void => {
           '@typescript-eslint/no-floating-promises': 'error',
           '@typescript-eslint/no-for-in-array': 'error',
           '@typescript-eslint/no-implied-eval': 'error',
+          '@typescript-eslint/no-invalid-void-type': 'error',
           '@typescript-eslint/no-misused-new': 'error',
           '@typescript-eslint/no-misused-promises': 'error',
           '@typescript-eslint/no-namespace': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@ import { rules as standardRules } from 'eslint-config-standard/eslintrc.json'
 
 const equivalents = [
   'comma-spacing',
+  'dot-notation',
   'brace-style',
   'func-call-spacing',
   'indent',
   'keyword-spacing',
+  'lines-between-class-members',
   'no-array-constructor',
   'no-dupe-class-members',
   'no-throw-literal',
@@ -86,6 +88,7 @@ export = {
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-for-in-array': 'error',
         '@typescript-eslint/no-implied-eval': 'error',
+        '@typescript-eslint/no-invalid-void-type': 'error',
         '@typescript-eslint/no-misused-new': 'error',
         '@typescript-eslint/no-misused-promises': 'error',
         '@typescript-eslint/no-namespace': 'error',


### PR DESCRIPTION
BREAKING CHANGE: peerDep bump

BREAKING CHANGE: new rule @typescript-eslint/dot-notation
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md

BREAKING CHANGE: new rule @typescript-eslint/lines-between-class-members
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/lines-between-class-members.md

BREAKING CHANGE: new rule @typescript-eslint/no-invalid-void-type
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-invalid-void-type.md

Closes #290.
Closes #291.
Closes #295.
Closes #297.