### PR TITLE
Use v3 of @typescript-eslint/eslint-plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ An [ESLint shareable config](https://eslint.org/docs/developer-guide/shareable-c
 ## Usage
 
 ```
-npm install --save-dev eslint@7 eslint-plugin-standard@4 eslint-plugin-promise@4 eslint-plugin-import@2 eslint-plugin-node@11 @typescript-eslint/eslint-plugin@2 eslint-config-standard-with-typescript
+npm install --save-dev eslint@7 eslint-plugin-standard@4 eslint-plugin-promise@4 eslint-plugin-import@2 eslint-plugin-node@11 @typescript-eslint/eslint-plugin eslint-config-standard-with-typescript
 ```
 
 Yes, this is a large number of packages. This is due to [a known limitation in ESLint](https://github.com/eslint/eslint/issues/3458).


### PR DESCRIPTION
It doesn't seem to break anything for me.

Note that **v3.0.1** is already used in **package.json**.

**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [x] Bug fix

**What changes did you make? (Give an overview)**
I removed the `@2` version constraint

**Which issue (if any) does this pull request address?**
Closes #351

**Is there anything you'd like reviewers to focus on?**
Was there a reason for this?
Would it be better to specify `@^3` or even `@3`?