### PR TITLE
chore: usage of @commitlint/config-conventional

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ['awesome'] }
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "eslint-config-standard": "^16.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=4.0.1",
     "eslint": ">=7.12.1",
     "eslint-plugin-import": ">=2.22.1",
     "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-promise": ">=4.2.1",
-    "typescript": ">=3.9"
+    "typescript": ">=3.9",
+    "@typescript-eslint/eslint-plugin": ">=4.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -59,21 +59,21 @@
     "eslint-config-standard": "^16.0.0"
   },
   "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": ">=4.0.1",
     "eslint": ">=7.12.1",
     "eslint-plugin-import": ">=2.22.1",
     "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-promise": ">=4.2.1",
-    "typescript": ">=3.9",
-    "@typescript-eslint/eslint-plugin": ">=4.0.1"
+    "typescript": ">=3.9"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",
+    "@commitlint/config-conventional": "11.0.0",
     "@commitlint/travis-cli": "11.0.0",
     "@types/eslint": "7.2.8",
     "@types/node": "14.14.37",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "ava": "3.15.0",
-    "commitlint-config-awesome": "1.0.4",
     "editorconfig-checker": "3.3.0",
     "eslint": "7.23.0",
     "eslint-plugin-import": "2.22.1",


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- [x] Change `commitlint-config-awesome` to `@commitlint/config-conventional`
`commitlint-config-awesome` is less used/updated (not updated since Dec 16, 2019), break on `npm@7` because peerDependency don't match and we don't need it anymore because we don't use anymore `Greenkeeper`, also `@commitlint/config-conventional` is what it is used for `ts-standard`.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
