### PR TITLE
test: fix issue with peerDeps checking with semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@commitlint/travis-cli": "12.1.4",
     "@types/eslint": "7.2.13",
     "@types/node": "14.17.3",
+    "@types/semver": "7.3.6",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "ava": "3.15.0",
     "editorconfig-checker": "4.0.2",
@@ -83,6 +84,7 @@
     "npm-run-all": "4.1.5",
     "pinst": "2.1.6",
     "read-pkg-up": "7.0.1",
+    "semver": "7.3.5",
     "standard-version": "9.3.0",
     "tsconfigs": "5.0.0",
     "typescript": "4.3.2"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import configStandard from './eslint-config-standard'
 import standardPkg from 'eslint-config-standard/package.json'
 import readPkgUp, { NormalizedPackageJson } from 'read-pkg-up'
 import { Linter } from 'eslint'
+import semver from 'semver'
 
 interface OurDeps {
   ourDeps: NonNullable<NormalizedPackageJson['dependencies']>
@@ -192,8 +193,7 @@ test('Own peerDependencies include those of eslint-config-standard', async (t) =
       const name = _name as keyof typeof standardPkg.peerDependencies
       const ourDep = ourPeerDeps[name]
       const ourRange = ourDep.split('>=')[1]
-      const standardRange = standardDep.split('^')[1]
-      t.is(ourRange, standardRange)
+      t.true(semver.satisfies(ourRange, standardDep))
     })
 })
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain: Updated the test, so it passes again

**What changes did you make? (Give an overview)**

Since `eslint-config-standard@16.0.3`, the test fails because the `peerDependencies` is like this `"eslint-plugin-promise": "^4.2.1 || ^5.0.0"`, and we were checking the strict equality, but instead we should use [semver](https://www.npmjs.com/package/semver) to check if it satisfies the `peerDependencies`.