### PR TITLE
fix: use typescript-eslint version of space-infix-ops rule

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,6 +65,7 @@ test('export', (t): void => {
           quotes: 'off',
           semi: 'off',
           'space-before-function-paren': 'off',
+          'space-infix-ops': 'off',
           '@typescript-eslint/adjacent-overload-signatures': 'error',
           '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
           '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
@@ -158,6 +159,7 @@ test('export', (t): void => {
           '@typescript-eslint/return-await': ['error', 'always'],
           '@typescript-eslint/semi': ['error', 'never'],
           '@typescript-eslint/space-before-function-paren': ['error', 'always'],
+          '@typescript-eslint/space-infix-ops': 'error',
           '@typescript-eslint/strict-boolean-expressions': ['error', {
             allowString: false,
             allowNumber: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ const equivalents = [
   'no-useless-constructor',
   'quotes',
   'semi',
-  'space-before-function-paren'
+  'space-before-function-paren',
+  'space-infix-ops'
 ] as const
 
 const ruleFromStandard = (name: string): Linter.RuleEntry => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Replaced `space-infix-ops` with `@typescript-eslint/space-infix-ops` as proposed in https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/space-infix-ops.md

**Which issue (if any) does this pull request address?**

This fixes the spacing around `|` in type definitions, like `arg: string | number` (instead of `string|number`).

**Is there anything you'd like reviewers to focus on?**

I'm not sure that this would work here, because I'm using these configs with eslint@8