### PR TITLE
feat: pin eslint-config-standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "@typescript-eslint/parser": "^5.0.0",
-    "eslint-config-standard": "^17.0.0"
+    "eslint-config-standard": "17.0.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,12 +192,11 @@ const isPinnedRange = (rangeStr: string): boolean => {
 
 test('Dependencies range types', async (t) => {
   const { ourDeps, ourPeerDeps, ourDevDeps } = await getPkgDetails()
-  for (const [name, range] of Object.entries(ourDeps)) {
-    t.true(
-      isSingleCaretRange(range),
-      `Regular dependency \`${name}: ${range}\` is a single \`^\` range.`
-    )
-  }
+
+  t.deepEqual(Object.keys(ourDeps).sort(), ['@typescript-eslint/parser', 'eslint-config-standard'])
+  t.true(isPinnedRange(ourDeps['eslint-config-standard']), 'eslint-config-standard is pinned')
+  t.true(isSingleCaretRange(ourDeps['@typescript-eslint/parser']), '@typescript-eslint/parser is a single `^` range.')
+
   for (const [name, range] of Object.entries(ourPeerDeps)) {
     if (name === 'typescript') {
       t.is(range, '*', 'Peer dependency typescript is `*`')


### PR DESCRIPTION
BREAKING CHANGE: the dependency eslint-config-standard is now pinned.

closes #849

Co-authored-by: Rostislav Simonik <rostislav.simonik@technologystudio.sk>
