### PR TITLE
feat: use all typescript-eslint equivalents

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-promise": "6.0.1",
     "inclusion": "1.0.1",
     "js-yaml": "4.1.0",
+    "just-diff": "5.1.1",
     "npm-package-arg": "9.1.0",
     "npm-run-all": "4.1.5",
     "read-pkg-up": "9.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,17 @@ const equivalents = [
   'lines-between-class-members',
   'no-array-constructor',
   'no-dupe-class-members',
+  'no-extra-parens',
+  'no-loss-of-precision',
   'no-redeclare',
   'no-throw-literal',
   'no-unused-vars',
   'no-unused-expressions',
   'no-useless-constructor',
+  'object-curly-spacing',
   'quotes',
   'semi',
+  'space-before-blocks',
   'space-before-function-paren',
   'space-infix-ops'
 ] as const
@@ -45,6 +49,8 @@ const config: Linter.Config = {
       files: ['*.ts', '*.tsx'],
       parser: '@typescript-eslint/parser',
       rules: {
+        'comma-dangle': 'off',
+
         // TypeScript has this functionality by default:
         'no-undef': 'off',
 
@@ -66,6 +72,16 @@ const config: Linter.Config = {
         // Rules exclusive to Standard TypeScript:
         '@typescript-eslint/adjacent-overload-signatures': 'error',
         '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+        '@typescript-eslint/comma-dangle': ['error', {
+          arrays: 'never',
+          objects: 'never',
+          imports: 'never',
+          exports: 'never',
+          functions: 'never',
+          enums: 'ignore',
+          generics: 'ignore',
+          tuples: 'ignore'
+        }],
         '@typescript-eslint/consistent-type-assertions': [
           'error',
           {


### PR DESCRIPTION
BREAKING CHANGE: add rules from @typescript-eslint: no-extra-parens,
no-loss-of-precision, object-curly-spacing, space-before-blocks,
comma-dangle.

Closes #582, closes #583.

Co-authored-by: Rostislav Simonik <rostislav.simonik@technologystudio.sk>
