### PR TITLE
feat: @typescript-eslint/consistent-generic-constructors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -152,6 +152,7 @@ test('export', (t): void => {
             tuples: 'ignore'
           }],
           '@typescript-eslint/comma-spacing': ['error', { before: false, after: true }],
+          '@typescript-eslint/consistent-generic-constructors': ['error', 'constructor'],
           '@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
           '@typescript-eslint/consistent-type-assertions': [
             'error',
@@ -420,7 +421,6 @@ test('all plugin rules are considered', (t) => {
   // and then fail upon plugin upgrades where new rules are released.
   const notYetConsideredRules: string[] = [
     'class-literal-property-style',
-    'consistent-generic-constructors',
     'consistent-type-exports',
     'consistent-type-imports',
     'default-param-last',

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ const config: Linter.Config = {
           generics: 'ignore',
           tuples: 'ignore'
         }],
+        '@typescript-eslint/consistent-generic-constructors': ['error', 'constructor'],
         '@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
         '@typescript-eslint/consistent-type-assertions': [
           'error',


### PR DESCRIPTION
BREAKING CHANGE: @typescript-eslint/consistent-generic-constructors
