### PR TITLE
build(renovate): do not bump @typescript-eslint_bottom/*

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
       "rangeStrategy": "pin"
     },
     {
+      "matchPackagePrefixes": ["@typescript-eslint_bottom/"],
+      "enabled": false
+    },
+    {
       "matchPackagePrefixes": ["@commitlint/"],
       "groupName": "@commitlint packages"
     },


### PR DESCRIPTION
Fixes #1083. At least, in theory.

Co-authored-by: Rostislav Simonik <rostislav.simonik@technologystudio.sk>
