### PR TITLE
fix(deps): eslint-config-standard and eslint-plugin-n

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,13 +54,13 @@
   ],
   "dependencies": {
     "@typescript-eslint/parser": "^5.50.0",
-    "eslint-config-standard": "17.0.0"
+    "eslint-config-standard": "17.1.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
     "eslint-plugin-promise": "^6.0.0",
     "typescript": "*"
   },
@@ -84,7 +84,7 @@
     "editorconfig-checker": "5.1.1",
     "eslint": "8.44.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-n": "15.7.0",
+    "eslint-plugin-n": "16.0.1",
     "eslint-plugin-promise": "6.1.1",
     "inclusion": "1.0.1",
     "js-yaml": "4.1.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -307,6 +307,8 @@ test('Dependencies range types', async (t) => {
   for (const [name, range] of Object.entries(ourPeerDeps as Record<string, string>)) {
     if (name === 'typescript') {
       t.is(range, '*', 'Peer dependency typescript is `*`')
+    } else if (name === 'eslint-plugin-n') {
+      t.is(range, '^15.0.0 || ^16.0.0 ', 'Peer dependency eslint-plugin-n is `^15.0.0 || ^16.0.0`')
     } else {
       t.true(
         isSingleCaretRange(range),


### PR DESCRIPTION
closes #1142

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

1. Dependencies
   - bump `eslint-config-standard` and `eslint-plugin-n` to latest
   - support v16 `eslint-plugin-n` in peerDependencies
2. Add a specific test for `eslint-plugin-n` because it will fail if goes to `isSingleCaretRange` check.

**Which issue (if any) does this pull request address?**
#1147
#1143
#1135
#1142

**Is there anything you'd like reviewers to focus on?**

The current problem that i don't like to spread is the `extra space` in `peerDependencies` from `eslint-plugin-n`, this comes from the [eslint-config-standard](https://github.com/standard/eslint-config-standard/blob/7d01bbc373bf3bb7374b698323032077ad05f6b1/package.json#L57)