### PR TITLE
feat: @typescript-eslint/block-spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "^5.50.0",
+    "@typescript-eslint/parser": "^5.52.0",
     "eslint-config-standard": "17.1.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/eslint-plugin": "^5.52.0",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
@@ -76,9 +76,9 @@
     "@types/npm-package-arg": "6.1.1",
     "@types/semver": "7.5.0",
     "@types/ungap__structured-clone": "0.3.0",
-    "@typescript-eslint_bottom/eslint-plugin": "npm:@typescript-eslint/eslint-plugin@5.50.0",
-    "@typescript-eslint_bottom/parser": "npm:@typescript-eslint/parser@5.50.0",
-    "@typescript-eslint/eslint-plugin": "5.50.0",
+    "@typescript-eslint_bottom/eslint-plugin": "npm:@typescript-eslint/eslint-plugin@5.52.0",
+    "@typescript-eslint_bottom/parser": "npm:@typescript-eslint/parser@5.52.0",
+    "@typescript-eslint/eslint-plugin": "5.62.0",
     "@ungap/structured-clone": "1.2.0",
     "ava": "5.3.1",
     "editorconfig-checker": "5.1.1",

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ npm install --save-dev \
   eslint-plugin-promise@^6.0.0 \
   eslint-plugin-import@^2.25.2 \
   eslint-plugin-n@^15.0.0 \
-  @typescript-eslint/eslint-plugin@^5.50.0 \
+  @typescript-eslint/eslint-plugin@^5.52.0 \
   eslint-config-standard-with-typescript@latest
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,6 +55,7 @@ test('export', (t): void => {
     plugins: ['@typescript-eslint'],
     parser: '@typescript-eslint/parser',
     rules: {
+      'block-spacing': 'off',
       'brace-style': 'off',
       camelcase: 'off',
       'comma-dangle': 'off',
@@ -142,6 +143,7 @@ test('export', (t): void => {
           }
         }
       }],
+      '@typescript-eslint/block-spacing': ['error', 'always'],
       '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
       '@typescript-eslint/class-literal-property-style': ['error', 'fields'],
       '@typescript-eslint/comma-dangle': ['error', {
@@ -432,10 +434,13 @@ test('all plugin rules are considered', (t) => {
     'member-ordering',
     'no-confusing-non-null-assertion',
     'no-duplicate-enum-values',
+    'no-duplicate-type-constituents',
     'no-explicit-any',
     'no-implicit-any-catch',
+    'no-import-type-side-effects',
     'no-inferrable-types',
     'no-meaningless-void-operator',
+    'no-mixed-enums',
     'no-non-null-asserted-nullish-coalescing',
     'no-parameter-properties',
     'no-redundant-type-constituents',
@@ -448,6 +453,7 @@ test('all plugin rules are considered', (t) => {
     'no-unsafe-assignment',
     'no-unsafe-call',
     'no-unsafe-declaration-merging',
+    'no-unsafe-enum-comparison',
     'no-unsafe-member-access',
     'no-unsafe-return',
     'no-useless-empty-export',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import configStandard from './eslint-config-standard'
 import { type Linter } from 'eslint'
 
 const equivalents = [
+  'block-spacing',
   'comma-spacing',
   'dot-notation',
   'brace-style',


### PR DESCRIPTION
BREAKING CHANGE: add rule @typescript-eslint/block-spacing and bump
minimum @typescript-eslint to 5.52.0

Co-authored-by: Rostislav Simonik <rostislav.simonik@technologystudio.sk>
